### PR TITLE
Fix: TextView 키보드 편집시 자동 레이아웃 기기별 대응

### DIFF
--- a/DRBS-HomeComing/View/VC/SettingSectionVC/WithdrawVC.swift
+++ b/DRBS-HomeComing/View/VC/SettingSectionVC/WithdrawVC.swift
@@ -6,8 +6,6 @@ final class WithdrawVC: UIViewController {
     
     // MARK: - Properties
     
-    private var responder: UIResponder?
-    
     private let infoTexts = [
         "탈퇴 후에는 작성하신 리뷰를 수정, 삭제하실 수 없습니다. 탈퇴 하시기 전에 확인해주세요!",
         "탈퇴 하시게 되면 등록, 저장했던 모든 정보는 삭제되어 복구할 수 없습니다.",


### PR DESCRIPTION
| iPhone SE | iPhone 14 Pro | iPhone 13 Mini |
| ------------- | ------------- | ------------- |
| ![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-08-30 at 23 46 18](https://github.com/IERO-6/DRBS-HomeComing/assets/117909631/6b43b935-7046-4e69-8517-0597e1849caf) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-08-30 at 23 47 04](https://github.com/IERO-6/DRBS-HomeComing/assets/117909631/e1987626-5a1a-43cb-9c59-a841f863bdc2) | ![Simulator Screen Recording - iPhone 13 mini - 2023-08-30 at 23 47 42](https://github.com/IERO-6/DRBS-HomeComing/assets/117909631/0028f5a6-3ff9-4392-9486-12fa5fea4c7b) |

* Pro Max 경우는 미적용 ㅠ.ㅠ (추후에 좀 더 알아 봐야할듯..)


