### PR TITLE
Fix: Tabbar 스크롤 다운 시 구분선 사라지는 오류 수정

### DIFF
--- a/DRBS-HomeComing.xcodeproj/project.pbxproj
+++ b/DRBS-HomeComing.xcodeproj/project.pbxproj
@@ -130,7 +130,6 @@
 		21B6276B2A83844400081D5E /* ModalVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalVC.swift; sourceTree = "<group>"; };
 		21B6276E2A83A95B00081D5E /* AnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationView.swift; sourceTree = "<group>"; };
 		21CD21EA2AB6C598009690DA /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		21CD21EC2AB6D0C0009690DA /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = config.xcconfig; sourceTree = "<group>"; };
 		21D7E6F52AC16472001D9F22 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		21F954142A9F78DD00F395B0 /* BookMarkCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookMarkCell.swift; sourceTree = "<group>"; };
 		6BB76A4B9218DD95A0E4D0C6 /* Pods-DRBS-HomeComing.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DRBS-HomeComing.debug.xcconfig"; path = "Target Support Files/Pods-DRBS-HomeComing/Pods-DRBS-HomeComing.debug.xcconfig"; sourceTree = "<group>"; };
@@ -627,6 +626,7 @@
 /* Begin XCBuildConfiguration section */
 		218ACDF12A75262500687EE6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EB2FF6A02AC20662004A3D79 /* config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -688,6 +688,7 @@
 		};
 		218ACDF22A75262500687EE6 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EB2FF6A02AC20662004A3D79 /* config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;

--- a/DRBS-HomeComing/Helpers/SceneDelegate.swift
+++ b/DRBS-HomeComing/Helpers/SceneDelegate.swift
@@ -57,10 +57,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         vc1.allHouseModels = houses
         vc2.houseViewModel.houses = houses
-        
-        let tabbarController = UITabBarController()
-        tabbarController.tabBar.tintColor = Constant.appColor
-        tabbarController.tabBar.backgroundColor = .white
+    
+        let tabbarController = Tabbar()
         tabbarController.viewControllers=[nav1 ,nav2]
         return tabbarController
 

--- a/DRBS-HomeComing/View/VC/Tabbar.swift
+++ b/DRBS-HomeComing/View/VC/Tabbar.swift
@@ -9,8 +9,13 @@ final class Tabbar: UITabBarController {
     }
     //MARK: - Helpers
     private func configureTabbar() {
+        let appearance = UITabBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        UITabBar.appearance().standardAppearance = appearance
+        UITabBar.appearance().scrollEdgeAppearance = UITabBar.appearance().standardAppearance
+        self.tabBar.standardAppearance = appearance
         self.tabBar.isTranslucent = false
-        self.tabBar.backgroundColor = .white
+        self.tabBar.barTintColor = .white
         self.tabBar.tintColor = Constant.appColor
     }
 }


### PR DESCRIPTION
iOS15 이상부터 탭바 + 테이블뷰 or 콜렉션 뷰 했을 때, 제일 하단의 화면으로 스크롤 되었을 때, 기본적으로 색상이 바뀜


[참조](https://stackoverflow.com/questions/67899805/ios-15-tab-bar-transparent-after-scrolling-to-the-bottom)